### PR TITLE
Revert "install google-closure-compiler via npm"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ language: generic
 before_install:
 - npm install
 install:
-- npm install google-closure-compiler:latest
+- wget https://dl.google.com/closure-compiler/compiler-latest.zip -O closure-compiler.zip
+- unzip closure-compiler.zip -d closure-compiler
 script:
 - printf "// $VERSION - $GH_SCRIPT_URL\n$(cat script.js)\n" > script.js
 - cat script.js


### PR DESCRIPTION
Reverts SimonLammer/anki-persistence#44

```
$ npm install google-closure-compiler:latest

npm ERR! code EINVALIDTAGNAME

npm ERR! Invalid tag name "google-closure-compiler:latest": Tags may not have any characters that encodeURIComponent encodes.

npm ERR! A complete log of this run can be found in:

npm ERR!     /home/travis/.npm/_logs/2020-10-06T05_49_50_771Z-debug.log

The command "npm install google-closure-compiler:latest" failed and exited with 1 during .
```